### PR TITLE
[TML-47] - Switch to OAuth2 security

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
   implementation 'org.springframework.boot:spring-boot-starter-validation'
   implementation 'org.springframework.boot:spring-boot-starter-web'
+  implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
   implementation 'org.liquibase:liquibase-core'
   implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
   implementation 'org.mapstruct:mapstruct:1.6.3'

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
   annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
 
   compileOnly 'org.projectlombok:lombok'
+  compileOnly 'com.google.guava:guava:32.0.1-android'
 
   developmentOnly 'org.springframework.boot:spring-boot-devtools'
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ dependencies {
   annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
 
   compileOnly 'org.projectlombok:lombok'
-  compileOnly 'com.google.guava:guava:32.0.1-android'
 
   developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
@@ -35,6 +34,7 @@ dependencies {
   implementation 'org.liquibase:liquibase-core'
   implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
   implementation 'org.mapstruct:mapstruct:1.6.3'
+  implementation 'com.google.guava:guava:32.0.1-jre'
 
   runtimeOnly 'org.postgresql:postgresql'
 

--- a/src/main/java/com/sava/teachernet/config/SecurityConfig.java
+++ b/src/main/java/com/sava/teachernet/config/SecurityConfig.java
@@ -23,6 +23,7 @@ import org.springframework.security.web.SecurityFilterChain;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+  public static final String LOGIN_PATH = "/auth/login";
   private final UserRepository userRepository;
 
   @Bean
@@ -42,13 +43,13 @@ public class SecurityConfig {
                 .requestMatchers("/teachers/**").hasRole("TEACHER")
                 .anyRequest().authenticated())
         .formLogin(form -> form
-            .loginPage("/auth/login")
-            .loginProcessingUrl("/auth/login")
+            .loginPage(LOGIN_PATH)
+            .loginProcessingUrl(LOGIN_PATH)
             .usernameParameter("login")
             .defaultSuccessUrl("/", true)
             .permitAll())
         .oauth2Login(oauth2 -> oauth2
-            .loginPage("/auth/login")
+            .loginPage(LOGIN_PATH)
             .defaultSuccessUrl("/", true)
             .userInfoEndpoint(userInfo -> userInfo
                 .userService(oauth2UserService(userRepository)))

--- a/src/main/java/com/sava/teachernet/config/SecurityConfig.java
+++ b/src/main/java/com/sava/teachernet/config/SecurityConfig.java
@@ -54,7 +54,7 @@ public class SecurityConfig {
             .userInfoEndpoint(userInfo -> userInfo
                 .userService(oauth2UserService(userRepository)))
             .successHandler((_, response, _) ->
-                response.sendRedirect("/")))
+                response.sendRedirect("/oauth2/registration")))
         .logout(logout -> logout
             .logoutUrl("/logout")
             .logoutSuccessUrl("/auth/login?logout")

--- a/src/main/java/com/sava/teachernet/config/SecurityConfig.java
+++ b/src/main/java/com/sava/teachernet/config/SecurityConfig.java
@@ -1,7 +1,5 @@
 package com.sava.teachernet.config;
 
-import static org.springframework.security.config.Customizer.withDefaults;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,6 +11,10 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -21,21 +23,43 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfig {
 
   @Bean
-  SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
-    return httpSecurity
+  SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http
         .csrf(AbstractHttpConfigurer::disable)
-        .sessionManagement(
-            session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
-        .authorizeHttpRequests(authorize -> authorize
-            .requestMatchers("/auth/**").permitAll()
-            .requestMatchers("/students").permitAll()
-            .requestMatchers("/teachers").permitAll()
-            .requestMatchers("/teachers/search").permitAll()
-            .requestMatchers("/students/**").hasRole("STUDENT")
-            .requestMatchers("/teachers/**").hasRole("TEACHER")
-            .anyRequest().authenticated())
-        .formLogin(withDefaults())
-        .build();
+        .sessionManagement(session -> session
+            .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
+        .authorizeHttpRequests(auth ->
+            auth
+                .requestMatchers("/auth/**", "/login", "/oauth2/**", "/webjars/**",
+                    "/css/**", "/js/**").permitAll()
+                .requestMatchers("/students").permitAll()
+                .requestMatchers("/teachers").permitAll()
+                .requestMatchers("/teachers/search").permitAll()
+                .requestMatchers("/students/**").hasRole("STUDENT")
+                .requestMatchers("/teachers/**").hasRole("TEACHER")
+                .anyRequest().authenticated())
+        .formLogin(form -> form
+            .loginPage("/auth/login")
+            .loginProcessingUrl("/auth/login")
+            .usernameParameter("login")
+            .passwordParameter("password")
+            .defaultSuccessUrl("/", true)
+            .permitAll())
+        .oauth2Login(oauth2 -> oauth2
+            .loginPage("/auth/login")
+            .defaultSuccessUrl("/", true)
+            .userInfoEndpoint(userInfo -> userInfo
+                .userService(oauth2UserService())))
+        .logout(logout -> logout
+            .logoutUrl("/logout")
+            .logoutSuccessUrl("/auth/login?logout")
+            .permitAll());
+    return http.build();
+  }
+
+  @Bean
+  public OAuth2UserService<OAuth2UserRequest, OAuth2User> oauth2UserService() {
+    return new DefaultOAuth2UserService();
   }
 
   @Bean

--- a/src/main/java/com/sava/teachernet/config/SecurityConfig.java
+++ b/src/main/java/com/sava/teachernet/config/SecurityConfig.java
@@ -50,10 +50,11 @@ public class SecurityConfig {
             .permitAll())
         .oauth2Login(oauth2 -> oauth2
             .loginPage(LOGIN_PATH)
-            .defaultSuccessUrl("/", true)
+            .defaultSuccessUrl("/oauth2/registration", true)
             .userInfoEndpoint(userInfo -> userInfo
                 .userService(oauth2UserService(userRepository)))
-            .successHandler((_, response, _) -> response.sendRedirect("/")))
+            .successHandler((_, response, _) ->
+                response.sendRedirect("/")))
         .logout(logout -> logout
             .logoutUrl("/logout")
             .logoutSuccessUrl("/auth/login?logout")

--- a/src/main/java/com/sava/teachernet/config/SecurityConfig.java
+++ b/src/main/java/com/sava/teachernet/config/SecurityConfig.java
@@ -11,7 +11,6 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -32,7 +31,6 @@ public class SecurityConfig {
   @Bean
   SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http
-        .csrf(AbstractHttpConfigurer::disable)
         .sessionManagement(session -> session
             .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
         .authorizeHttpRequests(auth ->

--- a/src/main/java/com/sava/teachernet/config/SecurityConfig.java
+++ b/src/main/java/com/sava/teachernet/config/SecurityConfig.java
@@ -54,7 +54,7 @@ public class SecurityConfig {
         .oauth2Login(oauth2 -> oauth2
             .loginPage(LOGIN_PATH)
             .userInfoEndpoint(userInfo -> userInfo
-                .userService(oauth2UserService(userRepository)))
+                .userService(oauth2UserService(userRepository, passwordEncoder())))
             .successHandler(customAuthenticationSuccessHandler))
         .logout(logout -> logout
             .logoutUrl("/logout")
@@ -65,8 +65,8 @@ public class SecurityConfig {
 
   @Bean
   public OAuth2UserService<OAuth2UserRequest, OAuth2User> oauth2UserService(
-      UserRepository userRepository) {
-    return new CustomOAuth2UserService(userRepository);
+      UserRepository userRepository, PasswordEncoder passwordEncoder) {
+    return new CustomOAuth2UserService(userRepository, passwordEncoder);
   }
 
   @Bean

--- a/src/main/java/com/sava/teachernet/config/auth/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/sava/teachernet/config/auth/CustomAuthenticationSuccessHandler.java
@@ -1,0 +1,31 @@
+package com.sava.teachernet.config.auth;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomAuthenticationSuccessHandler extends
+    SavedRequestAwareAuthenticationSuccessHandler {
+
+  public static final String REDIRECT_OAUTH2_REGISTRATION = "/oauth2/registration";
+
+  @Override
+  public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+      Authentication authentication) throws ServletException, IOException {
+    boolean isPendingRegistration = authentication.getAuthorities()
+        .contains(
+            new SimpleGrantedAuthority(UserRole.ROLE_PENDING_OAUTH2_REGISTRATION.getValue()));
+
+    if (isPendingRegistration) {
+      getRedirectStrategy().sendRedirect(request, response, REDIRECT_OAUTH2_REGISTRATION);
+    } else {
+      super.onAuthenticationSuccess(request, response, authentication);
+    }
+  }
+}

--- a/src/main/java/com/sava/teachernet/config/auth/UserRole.java
+++ b/src/main/java/com/sava/teachernet/config/auth/UserRole.java
@@ -2,7 +2,8 @@ package com.sava.teachernet.config.auth;
 
 public enum UserRole {
   STUDENT("ROLE_STUDENT"),
-  TEACHER("ROLE_TEACHER");
+  TEACHER("ROLE_TEACHER"),
+  ROLE_PENDING_OAUTH2_REGISTRATION("ROLE_PENDING_OAUTH2_REGISTRATION");
 
   private final String role;
 

--- a/src/main/java/com/sava/teachernet/controller/AuthController.java
+++ b/src/main/java/com/sava/teachernet/controller/AuthController.java
@@ -39,7 +39,7 @@ public class AuthController {
   @PostMapping("/login")
   public ResponseEntity<Void> signIn(SignInDto data) {
     var usernamePassword = new UsernamePasswordAuthenticationToken(data.login(), data.password());
-    var authUser = authenticationManager.authenticate(usernamePassword);
+    authenticationManager.authenticate(usernamePassword);
     return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/sava/teachernet/controller/AuthController.java
+++ b/src/main/java/com/sava/teachernet/controller/AuthController.java
@@ -1,12 +1,8 @@
 package com.sava.teachernet.controller;
 
-import com.sava.teachernet.dto.SignInDto;
 import com.sava.teachernet.dto.SignUpDto;
 import com.sava.teachernet.service.AuthService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,7 +13,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequiredArgsConstructor
 public class AuthController {
 
-  private final AuthenticationManager authenticationManager;
   private final AuthService service;
 
   @GetMapping("/signup")
@@ -34,12 +29,5 @@ public class AuthController {
   @GetMapping("/login")
   public String signInForm() {
     return "login";
-  }
-
-  @PostMapping("/login")
-  public ResponseEntity<Void> signIn(SignInDto data) {
-    var usernamePassword = new UsernamePasswordAuthenticationToken(data.login(), data.password());
-    authenticationManager.authenticate(usernamePassword);
-    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/sava/teachernet/controller/OAuth2RegistrationController.java
+++ b/src/main/java/com/sava/teachernet/controller/OAuth2RegistrationController.java
@@ -2,6 +2,7 @@ package com.sava.teachernet.controller;
 
 
 import static com.sava.teachernet.config.auth.UserRole.ROLE_PENDING_OAUTH2_REGISTRATION;
+import static com.sava.teachernet.util.Constants.REDIRECT_HOME_URL;
 
 import com.sava.teachernet.dto.RoleSelectionDto;
 import com.sava.teachernet.model.User;
@@ -35,48 +36,41 @@ public class OAuth2RegistrationController {
     Object principal = authentication.getPrincipal();
 
     if (principal instanceof OAuth2User oauth2User) {
-      String email = oauth2User.getAttribute("email");
-      if (email == null) {
-        email = oauth2User.getAttribute("login") + "@github.com";
-      }
-
-      User user = userRepository.findByLogin(email)
+      String login = oauth2User.getAttribute("login");
+      User user = userRepository.findByLogin(login)
           .orElseThrow(
               () -> new IllegalStateException("User not found after OAuth2 authentication"));
 
       if (!Objects.equals(user.getRole(), ROLE_PENDING_OAUTH2_REGISTRATION.name())) {
-        return "redirect:/";
+        return REDIRECT_HOME_URL;
       }
 
       model.addAttribute("roleSelection", new RoleSelectionDto());
       return "oauth2/select-role";
     }
-    return "redirect:/";
+    return REDIRECT_HOME_URL;
   }
 
   @PostMapping("/select-role")
   public String processRoleSelection(
       @Valid @ModelAttribute("roleSelection") RoleSelectionDto roleSelection,
       BindingResult result) {
-
     if (result.hasErrors()) {
       return "oauth2/select-role";
     }
-
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
     Object principal = authentication.getPrincipal();
 
     if (principal instanceof OAuth2User oauth2User) {
-      String email = oauth2User.getAttribute("email");
-      if (email == null) {
-        email = oauth2User.getAttribute("login") + "@github.com";
-      }
-      userRepository.findByLogin(email).ifPresent(user -> {
-        user.setRole(roleSelection.getRole());
-        userRepository.save(user);
-        authService.refreshAuthentication();
-      });
+      String login = oauth2User.getAttribute("login");
+
+      userRepository.findByLogin(login)
+          .ifPresent(user -> {
+            user.setRole(roleSelection.getRole());
+            userRepository.save(user);
+            authService.refreshAuthentication();
+          });
     }
-    return "redirect:/";
+    return REDIRECT_HOME_URL;
   }
 }

--- a/src/main/java/com/sava/teachernet/controller/OAuth2RegistrationController.java
+++ b/src/main/java/com/sava/teachernet/controller/OAuth2RegistrationController.java
@@ -1,0 +1,82 @@
+package com.sava.teachernet.controller;
+
+
+import static com.sava.teachernet.config.auth.UserRole.ROLE_PENDING_OAUTH2_REGISTRATION;
+
+import com.sava.teachernet.dto.RoleSelectionDto;
+import com.sava.teachernet.model.User;
+import com.sava.teachernet.repository.UserRepository;
+import com.sava.teachernet.service.AuthService;
+import jakarta.validation.Valid;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/oauth2")
+@RequiredArgsConstructor
+public class OAuth2RegistrationController {
+
+  private final UserRepository userRepository;
+  private final AuthService authService;
+
+  @GetMapping("/registration")
+  public String showRoleSelectionForm(Model model) {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    Object principal = authentication.getPrincipal();
+
+    if (principal instanceof OAuth2User oauth2User) {
+      String email = oauth2User.getAttribute("email");
+      if (email == null) {
+        email = oauth2User.getAttribute("login") + "@github.com";
+      }
+
+      User user = userRepository.findByLogin(email)
+          .orElseThrow(
+              () -> new IllegalStateException("User not found after OAuth2 authentication"));
+
+      if (!Objects.equals(user.getRole(), ROLE_PENDING_OAUTH2_REGISTRATION.name())) {
+        return "redirect:/";
+      }
+
+      model.addAttribute("roleSelection", new RoleSelectionDto());
+      return "oauth2/select-role";
+    }
+    return "redirect:/";
+  }
+
+  @PostMapping("/select-role")
+  public String processRoleSelection(
+      @Valid @ModelAttribute("roleSelection") RoleSelectionDto roleSelection,
+      BindingResult result) {
+
+    if (result.hasErrors()) {
+      return "oauth2/select-role";
+    }
+
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    Object principal = authentication.getPrincipal();
+
+    if (principal instanceof OAuth2User oauth2User) {
+      String email = oauth2User.getAttribute("email");
+      if (email == null) {
+        email = oauth2User.getAttribute("login") + "@github.com";
+      }
+      userRepository.findByLogin(email).ifPresent(user -> {
+        user.setRole(roleSelection.getRole());
+        userRepository.save(user);
+        authService.refreshAuthentication();
+      });
+    }
+    return "redirect:/";
+  }
+}

--- a/src/main/java/com/sava/teachernet/controller/OAuth2RegistrationController.java
+++ b/src/main/java/com/sava/teachernet/controller/OAuth2RegistrationController.java
@@ -1,19 +1,11 @@
 package com.sava.teachernet.controller;
 
-
-import static com.sava.teachernet.config.auth.UserRole.ROLE_PENDING_OAUTH2_REGISTRATION;
 import static com.sava.teachernet.util.Constants.REDIRECT_HOME_URL;
 
 import com.sava.teachernet.dto.RoleSelectionDto;
-import com.sava.teachernet.model.User;
-import com.sava.teachernet.repository.UserRepository;
-import com.sava.teachernet.service.AuthService;
+import com.sava.teachernet.service.OAuth2RegistrationService;
 import jakarta.validation.Valid;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -27,24 +19,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequiredArgsConstructor
 public class OAuth2RegistrationController {
 
-  private final UserRepository userRepository;
-  private final AuthService authService;
+  private final OAuth2RegistrationService oAuth2RegistrationService;
 
   @GetMapping("/registration")
   public String showRoleSelectionForm(Model model) {
-    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-    Object principal = authentication.getPrincipal();
-
-    if (principal instanceof OAuth2User oauth2User) {
-      String login = oauth2User.getAttribute("login");
-      User user = userRepository.findByLogin(login)
-          .orElseThrow(
-              () -> new IllegalStateException("User not found after OAuth2 authentication"));
-
-      if (!Objects.equals(user.getRole(), ROLE_PENDING_OAUTH2_REGISTRATION.name())) {
-        return REDIRECT_HOME_URL;
-      }
-
+    if (oAuth2RegistrationService.shouldShowRoleSelectionForm()) {
       model.addAttribute("roleSelection", new RoleSelectionDto());
       return "oauth2/select-role";
     }
@@ -58,19 +37,7 @@ public class OAuth2RegistrationController {
     if (result.hasErrors()) {
       return "oauth2/select-role";
     }
-    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-    Object principal = authentication.getPrincipal();
-
-    if (principal instanceof OAuth2User oauth2User) {
-      String login = oauth2User.getAttribute("login");
-
-      userRepository.findByLogin(login)
-          .ifPresent(user -> {
-            user.setRole(roleSelection.getRole());
-            userRepository.save(user);
-            authService.refreshAuthentication();
-          });
-    }
+    oAuth2RegistrationService.processRoleSelection(roleSelection);
     return REDIRECT_HOME_URL;
   }
 }

--- a/src/main/java/com/sava/teachernet/dto/RoleSelectionDto.java
+++ b/src/main/java/com/sava/teachernet/dto/RoleSelectionDto.java
@@ -1,0 +1,9 @@
+package com.sava.teachernet.dto;
+
+import lombok.Data;
+
+@Data
+public class RoleSelectionDto {
+
+  private String role;
+}

--- a/src/main/java/com/sava/teachernet/dto/RoleSelectionDto.java
+++ b/src/main/java/com/sava/teachernet/dto/RoleSelectionDto.java
@@ -1,9 +1,11 @@
 package com.sava.teachernet.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 @Data
 public class RoleSelectionDto {
 
+  @NotBlank(message = "Role must be selected")
   private String role;
 }

--- a/src/main/java/com/sava/teachernet/dto/RoleSelectionDto.java
+++ b/src/main/java/com/sava/teachernet/dto/RoleSelectionDto.java
@@ -1,11 +1,13 @@
 package com.sava.teachernet.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Data;
 
 @Data
 public class RoleSelectionDto {
 
   @NotBlank(message = "Role must be selected")
+  @Pattern(regexp = "ROLE_STUDENT|ROLE_TEACHER", message = "Invalid role selected")
   private String role;
 }

--- a/src/main/java/com/sava/teachernet/service/AuthService.java
+++ b/src/main/java/com/sava/teachernet/service/AuthService.java
@@ -17,7 +17,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -27,6 +27,7 @@ public class AuthService implements UserDetailsService {
   private final UserRepository userRepository;
   private final StudentService studentService;
   private final TeacherService teacherService;
+  private final PasswordEncoder passwordEncoder;
 
   @Override
   public UserDetails loadUserByUsername(String login) {
@@ -44,7 +45,7 @@ public class AuthService implements UserDetailsService {
     if (userRepository.findByLogin(data.login()).isPresent()) {
       throw new InvalidAuthException("Username already exists");
     }
-    String encryptedPassword = new BCryptPasswordEncoder().encode(data.password());
+    String encryptedPassword = passwordEncoder.encode(data.password());
     User newUser = new User(data.login(), encryptedPassword, data.role().getValue());
     userRepository.save(newUser);
 

--- a/src/main/java/com/sava/teachernet/service/AuthService.java
+++ b/src/main/java/com/sava/teachernet/service/AuthService.java
@@ -57,15 +57,13 @@ public class AuthService implements UserDetailsService {
   }
 
   /**
-   * Refreshes the current authentication with updated authorities. This is typically called after a
-   * user's role has been updated.
+   * Refreshes the current authentication with updated authorities
    */
   public void refreshAuthentication() {
     Authentication currentAuth = SecurityContextHolder.getContext().getAuthentication();
 
     if (currentAuth != null && currentAuth.isAuthenticated()) {
       String username = currentAuth.getName();
-
       UserDetails userDetails = loadUserByUsername(username);
 
       Authentication newAuth = new UsernamePasswordAuthenticationToken(

--- a/src/main/java/com/sava/teachernet/service/AuthService.java
+++ b/src/main/java/com/sava/teachernet/service/AuthService.java
@@ -10,8 +10,11 @@ import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -49,6 +52,27 @@ public class AuthService implements UserDetailsService {
       studentService.create(data.name(), data.lastName(), newUser);
     } else {
       teacherService.create(data.name(), data.lastName(), newUser);
+    }
+  }
+
+  /**
+   * Refreshes the current authentication with updated authorities. This is typically called after a
+   * user's role has been updated.
+   */
+  public void refreshAuthentication() {
+    Authentication currentAuth = SecurityContextHolder.getContext().getAuthentication();
+
+    if (currentAuth != null && currentAuth.isAuthenticated()) {
+      String username = currentAuth.getName();
+
+      UserDetails userDetails = loadUserByUsername(username);
+
+      Authentication newAuth = new UsernamePasswordAuthenticationToken(
+          userDetails,
+          currentAuth.getCredentials(),
+          userDetails.getAuthorities());
+
+      SecurityContextHolder.getContext().setAuthentication(newAuth);
     }
   }
 }

--- a/src/main/java/com/sava/teachernet/service/AuthService.java
+++ b/src/main/java/com/sava/teachernet/service/AuthService.java
@@ -63,8 +63,7 @@ public class AuthService implements UserDetailsService {
     Authentication currentAuth = SecurityContextHolder.getContext().getAuthentication();
 
     if (currentAuth != null && currentAuth.isAuthenticated()) {
-      String username = currentAuth.getName();
-      UserDetails userDetails = loadUserByUsername(username);
+      UserDetails userDetails = loadUserByUsername(currentAuth.getName());
 
       Authentication newAuth = new UsernamePasswordAuthenticationToken(
           userDetails,

--- a/src/main/java/com/sava/teachernet/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/sava/teachernet/service/CustomOAuth2UserService.java
@@ -31,12 +31,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     OAuth2User oauth2User = super.loadUser(userRequest);
     Map<String, Object> attributes = oauth2User.getAttributes();
 
-    String username;
-    if (attributes.get("email") == null) {
-      username = attributes.get("login") + "@github.com";
-    } else {
-      username = (String) attributes.get("email");
-    }
+    String username = attributes.get("login").toString();
 
     User user = userRepository.findByLogin(username).orElseGet(() -> {
       User newUser = new User();

--- a/src/main/java/com/sava/teachernet/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/sava/teachernet/service/CustomOAuth2UserService.java
@@ -2,6 +2,9 @@ package com.sava.teachernet.service;
 
 import com.sava.teachernet.model.User;
 import com.sava.teachernet.repository.UserRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -9,10 +12,6 @@ import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Collections;
-import java.util.Map;
-import java.util.Optional;
 
 @Service
 @Transactional
@@ -47,8 +46,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     }
 
     return new DefaultOAuth2User(
-        Collections.singletonList(() -> "ROLE_STUDENT"),
-        attributes,
-        "login");
+        List.of(() -> "ROLE_STUDENT"), attributes, "login");
   }
 }

--- a/src/main/java/com/sava/teachernet/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/sava/teachernet/service/CustomOAuth2UserService.java
@@ -1,5 +1,6 @@
 package com.sava.teachernet.service;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.sava.teachernet.config.auth.UserRole;
 import com.sava.teachernet.model.User;
 import com.sava.teachernet.repository.UserRepository;
@@ -29,6 +30,11 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
   @Override
   public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
     OAuth2User oauth2User = super.loadUser(userRequest);
+    return processOAuth2User(oauth2User);
+  }
+
+  @VisibleForTesting
+  OAuth2User processOAuth2User(OAuth2User oauth2User) {
     Map<String, Object> attributes = oauth2User.getAttributes();
 
     String username = attributes.get("login").toString();

--- a/src/main/java/com/sava/teachernet/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/sava/teachernet/service/CustomOAuth2UserService.java
@@ -1,0 +1,54 @@
+package com.sava.teachernet.service;
+
+import com.sava.teachernet.model.User;
+import com.sava.teachernet.repository.UserRepository;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@Transactional
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+  private final UserRepository userRepository;
+
+  public CustomOAuth2UserService(UserRepository userRepository) {
+    this.userRepository = userRepository;
+  }
+
+  @Override
+  public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+    OAuth2User oauth2User = super.loadUser(userRequest);
+    Map<String, Object> attributes = oauth2User.getAttributes();
+
+    String email = (String) attributes.get("email");
+    if (email == null) {
+      email = oauth2User.getAttribute("login") + "@github.com";
+    }
+
+    Optional<User> existingUser = userRepository.findByLogin(email);
+
+    if (existingUser.isEmpty()) {
+      User newUser = new User();
+      newUser.setLogin(email);
+      // TODO: require a user to specify a role
+      newUser.setRole("ROLE_STUDENT");
+      // TODO: require a user to change password
+      newUser.setPassword("{noop}oauth2user" + System.currentTimeMillis());
+      userRepository.save(newUser);
+    }
+
+    return new DefaultOAuth2User(
+        Collections.singletonList(() -> "ROLE_STUDENT"),
+        attributes,
+        "login");
+  }
+}

--- a/src/main/java/com/sava/teachernet/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/sava/teachernet/service/CustomOAuth2UserService.java
@@ -6,12 +6,14 @@ import com.sava.teachernet.model.User;
 import com.sava.teachernet.repository.UserRepository;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -26,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
   private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
 
   @Override
   public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -43,8 +46,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
       User newUser = new User();
       newUser.setLogin(username);
       newUser.setRole(UserRole.ROLE_PENDING_OAUTH2_REGISTRATION.name());
-      // TODO: require a user to change password
-      newUser.setPassword("{noop}oauth2user" + System.currentTimeMillis());
+      newUser.setPassword(passwordEncoder.encode(UUID.randomUUID().toString()));
       return userRepository.save(newUser);
     });
 

--- a/src/main/java/com/sava/teachernet/service/OAuth2RegistrationService.java
+++ b/src/main/java/com/sava/teachernet/service/OAuth2RegistrationService.java
@@ -1,0 +1,68 @@
+package com.sava.teachernet.service;
+
+import com.sava.teachernet.config.auth.UserRole;
+import com.sava.teachernet.dto.RoleSelectionDto;
+import com.sava.teachernet.model.User;
+import com.sava.teachernet.repository.UserRepository;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OAuth2RegistrationService {
+
+  private final StudentService studentService;
+  private final TeacherService teacherService;
+  private final UserRepository userRepository;
+  private final AuthService authService;
+
+  public void processRoleSelection(RoleSelectionDto roleSelection) {
+    getOauth2User().ifPresent(oauth2User -> {
+      String login = oauth2User.getAttribute("login");
+      userRepository.findByLogin(login).ifPresent(user -> {
+        user.setRole(roleSelection.getRole());
+        userRepository.save(user);
+        createRoleEntity(roleSelection, oauth2User, user);
+        authService.refreshAuthentication();
+      });
+    });
+  }
+
+  public boolean shouldShowRoleSelectionForm() {
+    return getOauth2User().map(oauth2User -> {
+      String login = oauth2User.getAttribute("login");
+      User user = userRepository.findByLogin(login)
+          .orElseThrow(
+              () -> new IllegalStateException("User not found after OAuth2 authentication"));
+      return Objects.equals(user.getRole(), UserRole.ROLE_PENDING_OAUTH2_REGISTRATION.getValue());
+    }).orElse(false);
+  }
+
+  private void createRoleEntity(RoleSelectionDto roleSelection, OAuth2User oauth2User, User user) {
+    String name = oauth2User.getAttribute("name");
+    String login = oauth2User.getAttribute("login");
+    String firstName = name != null ? name.split("\\s+")[0] : login;
+    String lastName = name != null && name.split("\\s+").length > 1
+        ? name.substring(firstName.length()).trim()
+        : "";
+
+    if (roleSelection.getRole().equals(UserRole.STUDENT.getValue())) {
+      studentService.create(firstName, lastName, user);
+    } else if (roleSelection.getRole().equals(UserRole.TEACHER.getValue())) {
+      teacherService.create(firstName, lastName, user);
+    }
+  }
+
+  private Optional<OAuth2User> getOauth2User() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication != null && authentication.getPrincipal() instanceof OAuth2User) {
+      return Optional.of((OAuth2User) authentication.getPrincipal());
+    }
+    return Optional.empty();
+  }
+}

--- a/src/main/java/com/sava/teachernet/service/StudentService.java
+++ b/src/main/java/com/sava/teachernet/service/StudentService.java
@@ -34,13 +34,13 @@ public class StudentService {
 
   private Student getCurrentStudent() {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-    Object userDetails = authentication.getPrincipal();
+    Object principal = authentication.getPrincipal();
 
     String username = null;
-    if (userDetails instanceof UserDetails) {
-      username = ((UserDetails) userDetails).getUsername();
-    } else if (userDetails instanceof OAuth2User) {
-      username = ((OAuth2User) userDetails).getAttribute("login");
+    if (principal instanceof UserDetails userDetails) {
+      username = userDetails.getUsername();
+    } else if (principal instanceof OAuth2User oauth2User) {
+      username = oauth2User.getAttribute("login");
     }
 
     return studentRepository.findByUserLogin(username)

--- a/src/main/java/com/sava/teachernet/service/StudentService.java
+++ b/src/main/java/com/sava/teachernet/service/StudentService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -33,9 +34,16 @@ public class StudentService {
 
   private Student getCurrentStudent() {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-    UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+    Object userDetails = authentication.getPrincipal();
 
-    return studentRepository.findByUserLogin(userDetails.getUsername())
+    String username = null;
+    if (userDetails instanceof UserDetails) {
+      username = ((UserDetails) userDetails).getUsername();
+    } else if (userDetails instanceof OAuth2User) {
+      username = ((OAuth2User) userDetails).getAttribute("login");
+    }
+
+    return studentRepository.findByUserLogin(username)
         .orElseThrow(() -> new EntityNotFoundException("Student not found"));
   }
 

--- a/src/main/java/com/sava/teachernet/util/Constants.java
+++ b/src/main/java/com/sava/teachernet/util/Constants.java
@@ -1,0 +1,9 @@
+package com.sava.teachernet.util;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class Constants {
+
+  public static final String REDIRECT_HOME_URL = "redirect:/";
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,3 +8,13 @@ spring:
     driverClassName: org.postgresql.Driver
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+  security:
+    oauth2:
+      client:
+        registration:
+          github:
+            client-id: ${GITHUB_CLIENT_ID}
+            client-secret: ${GITHUB_CLIENT_SECRET}
+          google:
+            client-id: your-google-client-id
+            client-secret: your-google-client-secret

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,5 +16,5 @@ spring:
             client-id: ${GITHUB_CLIENT_ID}
             client-secret: ${GITHUB_CLIENT_SECRET}
           google:
-            client-id: your-google-client-id
-            client-secret: your-google-client-secret
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,26 +1,28 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Login</title>
+  <title>Login - Teach Meets Learn</title>
   <style>
     body {
-        font-family: Arial, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
         margin: 0;
-        padding: 0;
+        padding: 20px;
         display: flex;
         justify-content: center;
         align-items: center;
-        height: 100vh;
+        min-height: 100vh;
         background-color: #f7f7f7;
     }
     .login-container {
         text-align: center;
         background-color: white;
-        padding: 20px;
-        border-radius: 5px;
-        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        padding: 40px;
+        border-radius: 8px;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+        width: 100%;
+        max-width: 400px;
     }
     h1 {
         color: #333;
@@ -42,17 +44,61 @@
         border-radius: 5px;
         box-sizing: border-box;
     }
-    input[type="submit"] {
+    .btn {
+        display: inline-block;
         padding: 10px 20px;
         border: none;
         border-radius: 5px;
-        background-color: #5cb85c;
         color: white;
         cursor: pointer;
         font-size: 16px;
+        text-decoration: none;
+        text-align: center;
+        transition: all 0.3s ease;
+        margin: 5px 0;
+        width: 100%;
+        box-sizing: border-box;
     }
-    input[type="submit"]:hover {
+
+    .btn-primary {
+        background-color: #5cb85c;
+    }
+
+    .btn-primary:hover {
         background-color: #4cae4c;
+    }
+
+    .btn-github {
+        background-color: #24292e;
+        margin-top: 15px;
+    }
+
+    .btn-github:hover {
+        background-color: #1b1f23;
+    }
+
+    .divider {
+        display: flex;
+        align-items: center;
+        text-align: center;
+        margin: 20px 0;
+        color: #6a737d;
+        font-size: 14px;
+    }
+
+    .divider::before,
+    .divider::after {
+        content: '';
+        flex: 1;
+        border-bottom: 1px solid #e1e4e8;
+    }
+
+    .divider::before {
+        margin-right: 10px;
+    }
+
+    .divider::after {
+        margin-left: 10px;
     }
     .error {
         color: red;
@@ -73,17 +119,30 @@
   </div>
 
   <form method="POST" th:action="@{/auth/login}" id="signInDto">
-    <label for="login">Login: </label>
-    <input type="text" name="login" id="login"/><br/>
+    <div style="margin-bottom: 15px;">
+      <label for="login">Email or Username</label>
+      <input type="text" name="login" id="login" class="form-control" style="width: 100%; padding: 10px; margin-top: 5px; border: 1px solid #ddd; border-radius: 4px; box-sizing: border-box;"/>
+    </div>
 
-    <label for="password">Password: </label>
-    <input type="password" name="password" id="password"/><br/>
+    <div style="margin-bottom: 20px;">
+      <label for="password">Password</label>
+      <input type="password" name="password" id="password" class="form-control" style="width: 100%; padding: 10px; margin-top: 5px; border: 1px solid #ddd; border-radius: 4px; box-sizing: border-box;"/>
+    </div>
 
-    <input type="submit" value="Login"/>
+    <button type="submit" class="btn btn-primary">Sign in</button>
   </form>
 
-  <p class="register-link">New here? Click
-    <a th:href="@{/auth/signup}">here</a> to register.
+  <div class="divider">OR</div>
+
+  <a th:href="@{/oauth2/authorization/github}" class="btn btn-github">
+    <svg height="20" viewBox="0 0 16 16" width="20" style="vertical-align: middle; margin-right: 8px;">
+      <path fill="#ffffff" d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"></path>
+    </svg>
+    Sign in with GitHub
+  </a>
+
+  <p class="register-link">
+    New here? <a th:href="@{/auth/signup}" class="register-here">Click here</a> to register.
   </p>
 </div>
 </body>

--- a/src/main/resources/templates/oauth2/select-role.html
+++ b/src/main/resources/templates/oauth2/select-role.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Select Your Role - Teach Meets Learn</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        body {
+            background-color: #f8f9fa;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            margin: 0;
+        }
+        .role-selection-container {
+            background: white;
+            padding: 2rem;
+            border-radius: 10px;
+            box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
+            width: 100%;
+            max-width: 500px;
+        }
+        .role-option {
+            border: 2px solid #dee2e6;
+            border-radius: 8px;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+            cursor: pointer;
+            transition: all 0.3s ease;
+        }
+        .role-option:hover {
+            border-color: #0d6efd;
+            background-color: #f8f9ff;
+        }
+        .role-option.active {
+            border-color: #0d6efd;
+            background-color: #f0f7ff;
+        }
+        .role-option input[type="radio"] {
+            display: none;
+        }
+        .btn-submit {
+            width: 100%;
+            padding: 0.75rem;
+            font-size: 1.1rem;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-8">
+                <div class="role-selection-container">
+                    <h2 class="text-center mb-4">Select Your Role</h2>
+                    <p class="text-muted text-center mb-4">Please choose how you'd like to use Teach Meets Learn</p>
+                    
+                    <form th:action="@{/oauth2/select-role}" method="post" th:object="${roleSelection}" id="roleForm">
+                        <div class="mb-3">
+                            <div class="role-option" onclick="selectRole('ROLE_STUDENT')">
+                                <input type="radio" id="role_student" th:field="*{role}" value="ROLE_STUDENT" required>
+                                <h5>👨‍🎓 I'm a Student</h5>
+                                <p class="text-muted mb-0">I want to learn from teachers and take courses.</p>
+                            </div>
+                            
+                            <div class="role-option" onclick="selectRole('ROLE_TEACHER')">
+                                <input type="radio" id="role_teacher" th:field="*{role}" value="ROLE_TEACHER">
+                                <h5>👨‍🏫 I'm a Teacher</h5>
+                                <p class="text-muted mb-0">I want to create and manage courses for students.</p>
+                            </div>
+                        </div>
+                        
+                        <div th:if="${#fields.hasErrors('role')}" class="alert alert-danger">
+                            <span th:errors="*{role}"></span>
+                        </div>
+                        
+                        <button type="submit" class="btn btn-primary btn-submit mt-3">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        function selectRole(role) {
+            // Update radio button
+            document.getElementById('role_' + role.toLowerCase().replace('role_', '')).checked = true;
+            
+            // Update UI
+            document.querySelectorAll('.role-option').forEach(option => {
+                option.classList.remove('active');
+            });
+            event.currentTarget.classList.add('active');
+        }
+        
+        // Initialize active state on page load if a role is already selected
+        document.addEventListener('DOMContentLoaded', function() {
+            const selectedRole = document.querySelector('input[name="role"]:checked');
+            if (selectedRole) {
+                selectedRole.closest('.role-option').classList.add('active');
+            }
+        });
+    </script>
+    
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/src/test/java/com/sava/teachernet/TeachMeetsLearnApplicationTest.java
+++ b/src/test/java/com/sava/teachernet/TeachMeetsLearnApplicationTest.java
@@ -2,9 +2,13 @@ package com.sava.teachernet;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
 class TeachMeetsLearnApplicationTest {
+	@MockitoBean
+	private ClientRegistrationRepository clientRegistrationRepository;
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/com/sava/teachernet/config/auth/CustomAuthenticationSuccessHandlerTest.java
+++ b/src/test/java/com/sava/teachernet/config/auth/CustomAuthenticationSuccessHandlerTest.java
@@ -1,0 +1,67 @@
+package com.sava.teachernet.config.auth;
+
+import static com.sava.teachernet.config.auth.CustomAuthenticationSuccessHandler.REDIRECT_OAUTH2_REGISTRATION;
+import static com.sava.teachernet.config.auth.UserRole.ROLE_PENDING_OAUTH2_REGISTRATION;
+import static com.sava.teachernet.config.auth.UserRole.STUDENT;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.web.RedirectStrategy;
+
+@ExtendWith(MockitoExtension.class)
+class CustomAuthenticationSuccessHandlerTest {
+
+  @Mock
+  private HttpServletRequest request;
+  @Mock
+  private HttpServletResponse response;
+  @Mock
+  private Authentication authentication;
+  @Mock
+  private RedirectStrategy redirectStrategy;
+
+  private CustomAuthenticationSuccessHandler successHandler;
+
+  @BeforeEach
+  void setUp() {
+    successHandler = new CustomAuthenticationSuccessHandler();
+    successHandler.setRedirectStrategy(redirectStrategy);
+  }
+
+  @Test
+  void onAuthenticationSuccess_whenPendingRegistration_thenRedirectsToRegistration()
+      throws IOException, ServletException {
+    when(authentication.getAuthorities())
+        .thenReturn((Collection) List.of(
+            new SimpleGrantedAuthority(ROLE_PENDING_OAUTH2_REGISTRATION.getValue())));
+
+    successHandler.onAuthenticationSuccess(request, response, authentication);
+
+    verify(redirectStrategy).sendRedirect(request, response, REDIRECT_OAUTH2_REGISTRATION);
+  }
+
+  @Test
+  void onAuthenticationSuccess_whenNotPendingRegistration_thenUsesDefaultBehavior()
+      throws IOException, ServletException {
+    successHandler.setDefaultTargetUrl("/");
+    when(authentication.getAuthorities())
+        .thenReturn((Collection) List.of(new SimpleGrantedAuthority(STUDENT.getValue())));
+
+    successHandler.onAuthenticationSuccess(request, response, authentication);
+
+    verify(redirectStrategy).sendRedirect(request, response, "/");
+  }
+}

--- a/src/test/java/com/sava/teachernet/controller/OAuth2RegistrationControllerTest.java
+++ b/src/test/java/com/sava/teachernet/controller/OAuth2RegistrationControllerTest.java
@@ -1,0 +1,85 @@
+package com.sava.teachernet.controller;
+
+import static com.sava.teachernet.util.Constants.REDIRECT_HOME_URL;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import com.sava.teachernet.config.auth.UserRole;
+import com.sava.teachernet.dto.RoleSelectionDto;
+import com.sava.teachernet.service.OAuth2RegistrationService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(OAuth2RegistrationController.class)
+class OAuth2RegistrationControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private OAuth2RegistrationService oAuth2RegistrationService;
+
+  @Test
+  @WithMockUser
+  void showRoleSelectionFormReturnsSelectRoleView() throws Exception {
+    when(oAuth2RegistrationService.shouldShowRoleSelectionForm()).thenReturn(true);
+
+    mockMvc.perform(get("/oauth2/registration")
+            .with(oauth2Login()))
+        .andExpect(status().isOk())
+        .andExpect(view().name("oauth2/select-role"))
+        .andExpect(model().attributeExists("roleSelection"));
+  }
+
+  @Test
+  @WithMockUser
+  void showRoleSelectionFormRedirectsHome() throws Exception {
+    when(oAuth2RegistrationService.shouldShowRoleSelectionForm()).thenReturn(false);
+
+    mockMvc.perform(get("/oauth2/registration")
+            .with(oauth2Login()))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(view().name(REDIRECT_HOME_URL));
+  }
+
+  @Test
+  @WithMockUser
+  void processRoleSelectionProcessesAndRedirects() throws Exception {
+    RoleSelectionDto roleSelection = new RoleSelectionDto();
+    roleSelection.setRole(UserRole.STUDENT.getValue());
+
+    mockMvc.perform(post("/oauth2/select-role")
+            .with(oauth2Login())
+            .with(csrf())
+            .flashAttr("roleSelection", roleSelection))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(view().name(REDIRECT_HOME_URL));
+
+    verify(oAuth2RegistrationService).processRoleSelection(roleSelection);
+  }
+
+  @Test
+  @WithMockUser
+  void processRoleSelectionReturnsSelectRoleViewOnInvalidInput() throws Exception {
+    RoleSelectionDto roleSelection = new RoleSelectionDto();
+    roleSelection.setRole(null);
+
+    mockMvc.perform(post("/oauth2/select-role")
+            .with(oauth2Login())
+            .with(csrf())
+            .flashAttr("roleSelection", roleSelection))
+        .andExpect(status().isOk())
+        .andExpect(view().name("oauth2/select-role"));
+  }
+}

--- a/src/test/java/com/sava/teachernet/controller/OAuth2RegistrationControllerTest.java
+++ b/src/test/java/com/sava/teachernet/controller/OAuth2RegistrationControllerTest.java
@@ -1,6 +1,8 @@
 package com.sava.teachernet.controller;
 
 import static com.sava.teachernet.util.Constants.REDIRECT_HOME_URL;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -81,5 +83,7 @@ class OAuth2RegistrationControllerTest {
             .flashAttr("roleSelection", roleSelection))
         .andExpect(status().isOk())
         .andExpect(view().name("oauth2/select-role"));
+
+    verify(oAuth2RegistrationService, never()).processRoleSelection(any(RoleSelectionDto.class));
   }
 }

--- a/src/test/java/com/sava/teachernet/service/CustomOAuth2UserServiceTest.java
+++ b/src/test/java/com/sava/teachernet/service/CustomOAuth2UserServiceTest.java
@@ -1,0 +1,75 @@
+package com.sava.teachernet.service;
+
+import static com.sava.teachernet.config.auth.UserRole.ROLE_PENDING_OAUTH2_REGISTRATION;
+import static com.sava.teachernet.util.TestDataFactory.createOauth2User;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.sava.teachernet.model.User;
+import com.sava.teachernet.repository.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@ExtendWith(MockitoExtension.class)
+class CustomOAuth2UserServiceTest {
+
+  @Mock
+  private UserRepository userRepository;
+
+  @InjectMocks
+  private CustomOAuth2UserService customOAuth2UserService;
+
+  @Captor
+  private ArgumentCaptor<User> userArgumentCaptor;
+
+  @ParameterizedTest
+  @ValueSource(strings = {"TEACHER", "STUDENT"})
+  void processOAuth2UserReturnsExistingUser(String role) {
+    String username = "testuser";
+    User existingUser = new User();
+    existingUser.setLogin(username);
+    existingUser.setRole(role);
+
+    OAuth2User oAuth2User = createOauth2User(username, role);
+
+    when(userRepository.findByLogin(username)).thenReturn(Optional.of(existingUser));
+
+    OAuth2User result = customOAuth2UserService.processOAuth2User(oAuth2User);
+
+    assertThat(result.getName()).isEqualTo(username);
+    assertThat(result.getAuthorities()).extracting("authority")
+        .contains(role);
+    verify(userRepository, never()).save(any(User.class));
+  }
+
+  @Test
+  void processOAuth2UserCreatesNewUser() {
+    String username = "newuser";
+    OAuth2User oAuth2User = createOauth2User(username, "some_oauth_role");
+    when(userRepository.findByLogin(username)).thenReturn(Optional.empty());
+    when(userRepository.save(any(User.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    OAuth2User result = customOAuth2UserService.processOAuth2User(oAuth2User);
+
+    assertThat(result.getName()).isEqualTo(username);
+    assertThat(result.getAuthorities()).extracting("authority")
+        .contains(ROLE_PENDING_OAUTH2_REGISTRATION.name());
+    verify(userRepository).save(userArgumentCaptor.capture());
+    User savedUser = userArgumentCaptor.getValue();
+    assertThat(savedUser.getLogin()).isEqualTo(username);
+    assertThat(savedUser.getRole()).isEqualTo(ROLE_PENDING_OAUTH2_REGISTRATION.name());
+  }
+}

--- a/src/test/java/com/sava/teachernet/service/CustomOAuth2UserServiceTest.java
+++ b/src/test/java/com/sava/teachernet/service/CustomOAuth2UserServiceTest.java
@@ -20,6 +20,7 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 @ExtendWith(MockitoExtension.class)
@@ -27,6 +28,9 @@ class CustomOAuth2UserServiceTest {
 
   @Mock
   private UserRepository userRepository;
+
+  @Mock
+  private PasswordEncoder passwordEncoder;
 
   @InjectMocks
   private CustomOAuth2UserService customOAuth2UserService;
@@ -61,6 +65,7 @@ class CustomOAuth2UserServiceTest {
     when(userRepository.findByLogin(username)).thenReturn(Optional.empty());
     when(userRepository.save(any(User.class)))
         .thenAnswer(invocation -> invocation.getArgument(0));
+    when(passwordEncoder.encode(any())).thenReturn("encoded-password");
 
     OAuth2User result = customOAuth2UserService.processOAuth2User(oAuth2User);
 
@@ -71,5 +76,7 @@ class CustomOAuth2UserServiceTest {
     User savedUser = userArgumentCaptor.getValue();
     assertThat(savedUser.getLogin()).isEqualTo(username);
     assertThat(savedUser.getRole()).isEqualTo(ROLE_PENDING_OAUTH2_REGISTRATION.name());
+    assertThat(savedUser.getPassword()).isEqualTo("encoded-password");
+    verify(passwordEncoder).encode(any());
   }
 }

--- a/src/test/java/com/sava/teachernet/service/TeacherServiceTest.java
+++ b/src/test/java/com/sava/teachernet/service/TeacherServiceTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
@@ -27,6 +28,8 @@ class TeacherServiceTest {
 
   @MockitoBean
   private TeacherRepository teacherRepository;
+  @MockitoBean
+  private ClientRegistrationRepository clientRegistrationRepository;
   @Autowired
   private TeacherMapper teacherMapper;
   @Autowired

--- a/src/test/java/com/sava/teachernet/util/Constants.java
+++ b/src/test/java/com/sava/teachernet/util/Constants.java
@@ -6,4 +6,5 @@ public class Constants {
   public static final String TEST_PASS = "123";
   public static final String TEST_USER_NAME = "Test";
   public static final String TEST_USER_LAST_NAME = "User";
+  public static final String TEST_USER_USERNAME = "testUser";
 }

--- a/src/test/java/com/sava/teachernet/util/Constants.java
+++ b/src/test/java/com/sava/teachernet/util/Constants.java
@@ -7,4 +7,5 @@ public class Constants {
   public static final String TEST_USER_NAME = "Test";
   public static final String TEST_USER_LAST_NAME = "User";
   public static final String TEST_USER_USERNAME = "testUser";
+  public static final String REDIRECT_HOME_URL = "redirect:/";
 }

--- a/src/test/java/com/sava/teachernet/util/TestDataFactory.java
+++ b/src/test/java/com/sava/teachernet/util/TestDataFactory.java
@@ -5,6 +5,7 @@ import static com.sava.teachernet.util.Constants.TEST_LOGIN;
 import static com.sava.teachernet.util.Constants.TEST_USER_LAST_NAME;
 import static com.sava.teachernet.util.Constants.TEST_USER_NAME;
 
+import com.sava.teachernet.config.auth.UserRole;
 import com.sava.teachernet.model.Student;
 import com.sava.teachernet.model.Teacher;
 import com.sava.teachernet.model.User;
@@ -45,5 +46,13 @@ public class TestDataFactory {
                 .authorities(STUDENT.getValue())
                 .password("pass")
                 .build(), null));
+  }
+
+  public static User buildTestUser() {
+    return User.builder()
+        .login("testUser")
+        .password("password")
+        .role(UserRole.STUDENT.getValue())
+        .build();
   }
 }

--- a/src/test/java/com/sava/teachernet/util/TestDataFactory.java
+++ b/src/test/java/com/sava/teachernet/util/TestDataFactory.java
@@ -9,11 +9,13 @@ import com.sava.teachernet.config.auth.UserRole;
 import com.sava.teachernet.model.Student;
 import com.sava.teachernet.model.Teacher;
 import com.sava.teachernet.model.User;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
@@ -27,7 +29,7 @@ public class TestDataFactory {
             .id(1L)
             .login(TEST_LOGIN)
             .build())
-        .teachers(List.of(buildTestTeacher()))
+        .teachers(new ArrayList<>(List.of(buildTestTeacher())))
         .build();
   }
 
@@ -43,13 +45,24 @@ public class TestDataFactory {
   }
 
   public static void setAuth() {
-    SecurityContextHolder.getContext()
-        .setAuthentication(new TestingAuthenticationToken(
-            org.springframework.security.core.userdetails.User.builder()
-                .username(TEST_LOGIN)
-                .authorities(STUDENT.getValue())
-                .password("pass")
-                .build(), null));
+    setAuth(false);
+  }
+
+  public static void setAuth(boolean isOauth) {
+    if (isOauth) {
+      OAuth2User oAuth2User = createOauth2User(TEST_LOGIN, STUDENT.name());
+      SecurityContextHolder.getContext()
+          .setAuthentication(
+              new OAuth2AuthenticationToken(oAuth2User, oAuth2User.getAuthorities(), "test-client"));
+    } else {
+      SecurityContextHolder.getContext()
+          .setAuthentication(new TestingAuthenticationToken(
+              org.springframework.security.core.userdetails.User.builder()
+                  .username(TEST_LOGIN)
+                  .authorities(STUDENT.getValue())
+                  .password("pass")
+                  .build(), null));
+    }
   }
 
   public static User buildTestUser() {

--- a/src/test/java/com/sava/teachernet/util/TestDataFactory.java
+++ b/src/test/java/com/sava/teachernet/util/TestDataFactory.java
@@ -10,8 +10,12 @@ import com.sava.teachernet.model.Student;
 import com.sava.teachernet.model.Teacher;
 import com.sava.teachernet.model.User;
 import java.util.List;
+import java.util.Map;
 import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 
 public class TestDataFactory {
 
@@ -54,5 +58,11 @@ public class TestDataFactory {
         .password("password")
         .role(UserRole.STUDENT.getValue())
         .build();
+  }
+
+  public static OAuth2User createOauth2User(String username, String role) {
+    Map<String, Object> attributes = Map.of("login", username);
+    var authorities = List.of(new SimpleGrantedAuthority(role));
+    return new DefaultOAuth2User(authorities, attributes, "login");
   }
 }


### PR DESCRIPTION
- Switched from Spring Security to OAuth2
- Implemented OAuth2 user creation
- Implementer user role choise
- Implemented OAuth2 role-based user entity creation (Student / Teacher)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OAuth2 login support for GitHub and Google.
  * Added a post-login role-selection step for new OAuth2 users (Student or Teacher).
  * Added a new role-selection UI page and flow to finalize role setup.

* **Bug Fixes**
  * Improved current-student resolution to work for both standard and OAuth2 sessions.
  * Updated login success handling and refresh authentication after role selection.

* **Documentation / UI**
  * Refreshed the login page styling and added an OAuth2 login link.
  * Improved navigation/redirect behavior for logout.

* **Tests**
  * Added/updated OAuth2 role-selection, login success, and authentication refresh tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->